### PR TITLE
Add Haiku as a built host option

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3821,7 +3821,7 @@ class DXXCommon(LazyObjectConstructor):
 						'cross-compile to specified platform',
 						{
 							'map': {'msys':'win32'},
-							'allowed_values' : ('darwin', 'linux', 'freebsd', 'openbsd', 'win32'),
+							'allowed_values' : ('darwin', 'linux', 'freebsd', 'openbsd', 'win32', 'haiku1'),
 							}
 						),
 					('raspberrypi', None, 'build for Raspberry Pi (automatically selects opengles)', {'ignorecase': 2, 'map': {'1':'yes', 'true':'yes', '0':'no', 'false':'no'}, 'allowed_values': ('yes', 'no', 'mesa')}),


### PR DESCRIPTION
Haiku has all the necessary tools to build dxx-rebirth, but is not a valid build host option. This change should allow dxx-rebirth to build in a Haiku dev environment.

Any additional changes I may have missed are welcome.